### PR TITLE
Species and genome build selection

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -414,8 +414,8 @@ function init() {
           onRefreshShowAnalysis(vcfUrl, tbiUrl, sampleNamesFromUrl && sampleNamesFromUrl.length >  0 ? sampleNamesFromUrl.split(",") : null);
 
         } else if (vcfUrl) {
-          console.log(typeof species)
-          if(species === "Not specified" || species === "" || species === "null"){
+          console.log(species)
+          if(species === "Not specified" || species === "" || species === "null" || build=== "Not specified" || build === "GRCh37" || build === "GRCh38" || build=== "mm10/GRCm38"){
             $('#url-input').val("");
             if (tbiUrl) {
               $('#url-tbi-input').val("");
@@ -914,11 +914,44 @@ function loadFromFile() {
     }
     else {
       //If the file contains no samples.
-      $("#go-button-for-noSamples").prop('disabled', false).removeClass("hide");
+      console.log("here for file");
+      var speciesFlagNoSamples = false;
+      var buildFlagNoSamples = false;
+
+      if($('#select-build')[0].selectize.getValue() && $('#select-species')[0].selectize.getValue()){
+        $("#go-button-for-noSamples").prop('disabled', false);
+      }
+
+      $('#select-species')[0].selectize.on("change", function(){
+        if($('#select-species')[0].selectize.getValue().length>0){
+          if($('#select-species')[0].selectize.getValue() === "Not specified"){
+            window.history.pushState({'index.html' : 'bar'},null,'?build=not specified' + '&species=not specified');
+            genomeBuildHelper.setCurrentBuild("not specified")
+            speciesFlagNoSamples = true;
+            $("#go-button-for-noSamples").prop('disabled', false)
+          }
+          else{
+            speciesFlagNoSamples = true;
+            checkBuildSpeciesNoSampleData(buildFlagNoSamples, speciesFlagNoSamples);
+          }
+        }
+      });
+
+      $('#select-build')[0].selectize.on("change", function(){
+        if($('#select-build')[0].selectize.getValue().length>0){
+          buildFlagNoSamples = true;
+          checkBuildSpeciesNoSampleData(buildFlagNoSamples, speciesFlagNoSamples);
+        }
+      });
+
+      $("#go-button-for-noSamples").removeClass("hide");
+      // $("#go-button-for-noSamples").prop('disabled', false).removeClass("hide");
       $("#accessing-headers-gif").addClass("hide"); //Hide the loading gif
+      $("#select-species-box").removeClass("hide"); //Show the select species box
       $("#select-build-box").removeClass("hide"); //Show the select build box
 
       $("#go-button-for-noSamples").on("click", function(){
+        printBuildName();
         vcfiobio.loadIndex(onReferencesLoading, onReferencesLoaded, displayFileError);
         toggleDisplayProperties();
       })
@@ -928,6 +961,7 @@ function loadFromFile() {
 
 function handleSampleGoButtonForFile(){
   $('#sample-go-button').on('click', function() {
+    printBuildName();
       if (samplesSet===false) {
         samplesSet=true;
         toggleDisplayProperties();
@@ -1042,6 +1076,7 @@ function _loadVcfFromUrl(url, tbiUrl, sampleNames) {
         handleSampleGoButtonClick(url, tbiUrl, onReferencesLoading, onReferencesLoaded);
         }
         else {
+          //If the url contains no samples.
           // $("#go-button-for-noSamples").prop('disabled', false).removeClass("hide");
           console.log("here")
           var speciesFlagNoSamples = false;

--- a/app/app.js
+++ b/app/app.js
@@ -400,7 +400,6 @@ function init() {
           genomeBuildHelper.setCurrentSpecies(species);
         }
         var build   = getParameterByName('build');
-        console.log("build", build)
         if (build && build.length > 0) {
           $('#current-build').text(build)
           genomeBuildHelper.setCurrentBuild(build);
@@ -410,11 +409,9 @@ function init() {
         var tbiUrl = decodeUrl(getParameterByName('tbi'));
 
         if (vcfUrl && genomeBuildHelper.getCurrentBuild() && genomeBuildHelper.getCurrentSpecies()) {
-          console.log("hola")
           onRefreshShowAnalysis(vcfUrl, tbiUrl, sampleNamesFromUrl && sampleNamesFromUrl.length >  0 ? sampleNamesFromUrl.split(",") : null);
 
         } else if (vcfUrl) {
-          console.log(species)
           if(species === "Not specified" || species === "" || species === "null" || build=== "Not specified" || build === "GRCh37" || build === "GRCh38" || build=== "mm10/GRCm38"){
             $('#url-input').val("");
             if (tbiUrl) {
@@ -620,15 +617,6 @@ function emailProblem() {
     var species_dropdownValue = $('#select-species').selectize();
     var selectize_species  = species_dropdownValue[0].selectize;
     selectize_species.setValue("Human");
-    // genomeBuildHelper.setCurrentBuild("null")
-
-    // var selectTheOptions = $("#select-build").selectize();
-    // var control = selectTheOptions[0].selectize;
-    // control.clearOptions();
-
-    setTimeout(function(){
-      console.log("genomeBuildHelper.getCurrentBuildName()", genomeBuildHelper.getCurrentBuildName());
-    }, 5000)
 
     //If flag is set and tbi url is entered first
     if(document.getElementById("url-input").value.length > 5 && document.getElementById("url-tbi-input").value.length > 5 && flag){
@@ -725,46 +713,17 @@ function displayVcfUrlBox() {
     vcfiobio.tbiURL = $('#url-tbi-input').val();
     dataSelect.setDefaultBuildFromData(); //builds data for species and genome build
     loadWithSample();
-    //
-    // var species_dropdownValue = $('#select-species').selectize();
-    // var selectize_species  = species_dropdownValue[0].selectize;
-    // selectize_species.setValue("Human");
-    //
-    // setTimeout(function(){
-    //   var build_dropdownValue = $('#select-build').selectize();
-    //   var selectize_build  = build_dropdownValue[0].selectize;
-    //   // console.log("selectize.options", selectize_build.options)
-    //   selectize_build.setValue("GRCh37");
-    //   $("#go-button-for-load").prop('disabled', false).removeClass("disabled");
-    //   demoFlag = false;
-    // }, 1000)
-
-
-
 
     $('#select-species')[0].selectize.on("change", function(){
       if($('#select-species')[0].selectize.getValue().length>0){
         demoSpeciesFlag = true;
-        console.log("$('#select-build')[0].selectize.getValue()", $('#select-build')[0].selectize.getValue());
-        // genomeBuildHelper.setCurrentBuild("not specified")
-        console.log("genomeBuildHelper.getCurrentBuildName()", genomeBuildHelper.getCurrentBuildName());
-        // window.history.pushState({'index.html' : 'bar'},null,'?build=null'+ '&species=' + genomeBuildHelper.getCurrentSpeciesName());
-
         checkToEnableDemoLoadButton();
       }
     })
-    //
-    // $('#select-build')[0].selectize.on("change", function(){
-    //   if($('#select-build')[0].selectize.getValue().length>0){
-    //     demoBuildFlag = true;
-    //     checkToEnableDemoLoadButton();
-    //   }
-    // })
-
 }
+
 function checkToEnableDemoLoadButton(){
   if(demoBuildFlag && demoSpeciesFlag && demoFlag){
-    // $("#go-button-for-load").removeClass("hide");
     $("#go-button-for-load").prop('disabled', false).removeClass("disabled");
     demoFlag = false;
   }
@@ -914,7 +873,6 @@ function loadFromFile() {
     }
     else {
       //If the file contains no samples.
-      console.log("here for file");
       var speciesFlagNoSamples = false;
       var buildFlagNoSamples = false;
 
@@ -1077,8 +1035,6 @@ function _loadVcfFromUrl(url, tbiUrl, sampleNames) {
         }
         else {
           //If the url contains no samples.
-          // $("#go-button-for-noSamples").prop('disabled', false).removeClass("hide");
-          console.log("here")
           var speciesFlagNoSamples = false;
           var buildFlagNoSamples = false;
 
@@ -1086,7 +1042,6 @@ function _loadVcfFromUrl(url, tbiUrl, sampleNames) {
             $("#go-button-for-noSamples").prop('disabled', false);
           }
 
-          console.log("$('#select-species')[0].selectize.getValue()", $('#select-build')[0].selectize.getValue())
           $('#select-species')[0].selectize.on("change", function(){
             if($('#select-species')[0].selectize.getValue().length>0){
               if($('#select-species')[0].selectize.getValue() === "Not specified"){

--- a/app/app.js
+++ b/app/app.js
@@ -616,11 +616,11 @@ function emailProblem() {
 
 
   function urlFunction(){
-    console.log("ejessd")
-    // window.history.pushState({'index.html' : 'bar'},null,'?build=null' + '&species=' + genomeBuildHelper.getCurrentSpeciesName());
+    window.history.pushState({'index.html' : 'bar'},null,'?build=null' + '&species=' + genomeBuildHelper.getCurrentSpeciesName());
     var species_dropdownValue = $('#select-species').selectize();
     var selectize_species  = species_dropdownValue[0].selectize;
     selectize_species.setValue("Human");
+    // genomeBuildHelper.setCurrentBuild("null")
 
     // var selectTheOptions = $("#select-build").selectize();
     // var control = selectTheOptions[0].selectize;
@@ -725,19 +725,19 @@ function displayVcfUrlBox() {
     vcfiobio.tbiURL = $('#url-tbi-input').val();
     dataSelect.setDefaultBuildFromData(); //builds data for species and genome build
     loadWithSample();
-
-    var species_dropdownValue = $('#select-species').selectize();
-    var selectize_species  = species_dropdownValue[0].selectize;
-    selectize_species.setValue("Human");
-
-    setTimeout(function(){
-      var build_dropdownValue = $('#select-build').selectize();
-      var selectize_build  = build_dropdownValue[0].selectize;
-      // console.log("selectize.options", selectize_build.options)
-      selectize_build.setValue("GRCh37");
-      $("#go-button-for-load").prop('disabled', false).removeClass("disabled");
-      demoFlag = false;
-    }, 1000)
+    //
+    // var species_dropdownValue = $('#select-species').selectize();
+    // var selectize_species  = species_dropdownValue[0].selectize;
+    // selectize_species.setValue("Human");
+    //
+    // setTimeout(function(){
+    //   var build_dropdownValue = $('#select-build').selectize();
+    //   var selectize_build  = build_dropdownValue[0].selectize;
+    //   // console.log("selectize.options", selectize_build.options)
+    //   selectize_build.setValue("GRCh37");
+    //   $("#go-button-for-load").prop('disabled', false).removeClass("disabled");
+    //   demoFlag = false;
+    // }, 1000)
 
 
 
@@ -746,9 +746,9 @@ function displayVcfUrlBox() {
       if($('#select-species')[0].selectize.getValue().length>0){
         demoSpeciesFlag = true;
         console.log("$('#select-build')[0].selectize.getValue()", $('#select-build')[0].selectize.getValue());
-        genomeBuildHelper.setCurrentBuild("null")
+        // genomeBuildHelper.setCurrentBuild("not specified")
         console.log("genomeBuildHelper.getCurrentBuildName()", genomeBuildHelper.getCurrentBuildName());
-        window.history.pushState({'index.html' : 'bar'},null,'?build=null'+ '&species=' + genomeBuildHelper.getCurrentSpeciesName());
+        // window.history.pushState({'index.html' : 'bar'},null,'?build=null'+ '&species=' + genomeBuildHelper.getCurrentSpeciesName());
 
         checkToEnableDemoLoadButton();
       }
@@ -781,7 +781,7 @@ function loadWithSample(){
 
       var tbiUrl = $("#url-tbi-input").val();
       updateUrl("tbi",  encodeURIComponent(tbiUrl));
-
+      printBuildName();
       _loadDemoVcfFromUrl(url, tbiUrl);
   }
 
@@ -815,6 +815,13 @@ function loadWithSample(){
     });
   }
 
+
+function printBuildName(){
+  var build   = getParameterByName('build');
+  if (build && build.length > 0) {
+    $('#current-build').text(build)
+  }
+}
 
 function onFileButtonClicked() {
     $('#vcf-url').css('visibility', 'hidden');
@@ -1036,13 +1043,20 @@ function _loadVcfFromUrl(url, tbiUrl, sampleNames) {
         }
         else {
           // $("#go-button-for-noSamples").prop('disabled', false).removeClass("hide");
-
+          console.log("here")
           var speciesFlagNoSamples = false;
           var buildFlagNoSamples = false;
 
+          if($('#select-build')[0].selectize.getValue() && $('#select-species')[0].selectize.getValue()){
+            $("#go-button-for-noSamples").prop('disabled', false);
+          }
+
+          console.log("$('#select-species')[0].selectize.getValue()", $('#select-build')[0].selectize.getValue())
           $('#select-species')[0].selectize.on("change", function(){
             if($('#select-species')[0].selectize.getValue().length>0){
               if($('#select-species')[0].selectize.getValue() === "Not specified"){
+                window.history.pushState({'index.html' : 'bar'},null,'?build=not specified' + '&species=not specified');
+                genomeBuildHelper.setCurrentBuild("not specified")
                 speciesFlagNoSamples = true;
                 $("#go-button-for-noSamples").prop('disabled', false)
               }
@@ -1083,7 +1097,12 @@ function _loadVcfFromUrl(url, tbiUrl, sampleNames) {
 }
 
 function checkBuildSpeciesNoSampleData(buildFlagNoSamples, speciesFlagNoSamples){
-  $("#go-button-for-noSamples").prop('disabled', false);
+  if(buildFlagNoSamples && speciesFlagNoSamples){
+    $("#go-button-for-noSamples").prop('disabled', false);
+  }
+  else {
+    $("#go-button-for-noSamples").prop('disabled', true);
+  }
 }
 
 function enableSampleSelectDropDown(){
@@ -1100,6 +1119,7 @@ function handleSampleGoButtonNoSamples(url, tbiUrl, onReferencesLoading, onRefer
   $("#go-button-for-noSamples").on("click", function(){
     updateUrl("vcf",  encodeURIComponent(url));
     updateUrl("tbi",  encodeURIComponent(tbiUrl));
+    printBuildName();
     toggleDisplayProperties();
     vcfiobio.loadRemoteIndex(url, tbiUrl, onReferencesLoading, onReferencesLoaded);
 
@@ -1110,6 +1130,7 @@ function handleSampleGoButtonClick(url, tbiUrl, onReferencesLoading, onReference
   $('#sample-go-button').on('click', function() {
     updateUrl("vcf",  encodeURIComponent(url));
     updateUrl("tbi",  encodeURIComponent(tbiUrl));
+    printBuildName();
       if (!samplesSet) { //Check if we are on the home page or analysis page
         samplesSet=true;
         toggleDisplayProperties();

--- a/app/app.js
+++ b/app/app.js
@@ -400,6 +400,7 @@ function init() {
           genomeBuildHelper.setCurrentSpecies(species);
         }
         var build   = getParameterByName('build');
+        console.log("build", build)
         if (build && build.length > 0) {
           $('#current-build').text(build)
           genomeBuildHelper.setCurrentBuild(build);
@@ -615,6 +616,20 @@ function emailProblem() {
 
 
   function urlFunction(){
+    console.log("ejessd")
+    // window.history.pushState({'index.html' : 'bar'},null,'?build=null' + '&species=' + genomeBuildHelper.getCurrentSpeciesName());
+    var species_dropdownValue = $('#select-species').selectize();
+    var selectize_species  = species_dropdownValue[0].selectize;
+    selectize_species.setValue("Human");
+
+    // var selectTheOptions = $("#select-build").selectize();
+    // var control = selectTheOptions[0].selectize;
+    // control.clearOptions();
+
+    setTimeout(function(){
+      console.log("genomeBuildHelper.getCurrentBuildName()", genomeBuildHelper.getCurrentBuildName());
+    }, 5000)
+
     //If flag is set and tbi url is entered first
     if(document.getElementById("url-input").value.length > 5 && document.getElementById("url-tbi-input").value.length > 5 && flag){
       $("#accessing-headers-gif").removeClass("hide");
@@ -644,6 +659,7 @@ function emailProblem() {
 
   function clearUrlFunction(){
     //Clear the samples
+
     demoFlag = false;
     var selectTheOptions = $("#vcf-sample-select").selectize();
 		var control = selectTheOptions[0].selectize;
@@ -710,19 +726,40 @@ function displayVcfUrlBox() {
     dataSelect.setDefaultBuildFromData(); //builds data for species and genome build
     loadWithSample();
 
+    var species_dropdownValue = $('#select-species').selectize();
+    var selectize_species  = species_dropdownValue[0].selectize;
+    selectize_species.setValue("Human");
+
+    setTimeout(function(){
+      var build_dropdownValue = $('#select-build').selectize();
+      var selectize_build  = build_dropdownValue[0].selectize;
+      // console.log("selectize.options", selectize_build.options)
+      selectize_build.setValue("GRCh37");
+      $("#go-button-for-load").prop('disabled', false).removeClass("disabled");
+      demoFlag = false;
+    }, 1000)
+
+
+
+
     $('#select-species')[0].selectize.on("change", function(){
       if($('#select-species')[0].selectize.getValue().length>0){
         demoSpeciesFlag = true;
-        checkToEnableDemoLoadButton();
-      }
-    })
+        console.log("$('#select-build')[0].selectize.getValue()", $('#select-build')[0].selectize.getValue());
+        genomeBuildHelper.setCurrentBuild("null")
+        console.log("genomeBuildHelper.getCurrentBuildName()", genomeBuildHelper.getCurrentBuildName());
+        window.history.pushState({'index.html' : 'bar'},null,'?build=null'+ '&species=' + genomeBuildHelper.getCurrentSpeciesName());
 
-    $('#select-build')[0].selectize.on("change", function(){
-      if($('#select-build')[0].selectize.getValue().length>0){
-        demoBuildFlag = true;
         checkToEnableDemoLoadButton();
       }
     })
+    //
+    // $('#select-build')[0].selectize.on("change", function(){
+    //   if($('#select-build')[0].selectize.getValue().length>0){
+    //     demoBuildFlag = true;
+    //     checkToEnableDemoLoadButton();
+    //   }
+    // })
 
 }
 function checkToEnableDemoLoadButton(){

--- a/app/app.js
+++ b/app/app.js
@@ -703,7 +703,7 @@ function displayVcfUrlBox() {
     $("#vcf-sample-select-box").addClass("hide");
     $("#all-sample-go-button").addClass("hide");
     $("#sample-go-button").addClass("hide");
-    // $("#go-button-for-load").removeClass("hide");
+    $("#go-button-for-load").removeClass("hide");
 
     vcfiobio.vcfURL = $('#url-input').val();
     vcfiobio.tbiURL = $('#url-tbi-input').val();
@@ -724,11 +724,11 @@ function displayVcfUrlBox() {
       }
     })
 
-
 }
 function checkToEnableDemoLoadButton(){
   if(demoBuildFlag && demoSpeciesFlag && demoFlag){
-    $("#go-button-for-load").removeClass("hide");
+    // $("#go-button-for-load").removeClass("hide");
+    $("#go-button-for-load").prop('disabled', false).removeClass("disabled");
     demoFlag = false;
   }
 }
@@ -998,7 +998,32 @@ function _loadVcfFromUrl(url, tbiUrl, sampleNames) {
         handleSampleGoButtonClick(url, tbiUrl, onReferencesLoading, onReferencesLoaded);
         }
         else {
-          $("#go-button-for-noSamples").prop('disabled', false).removeClass("hide");
+          // $("#go-button-for-noSamples").prop('disabled', false).removeClass("hide");
+
+          var speciesFlagNoSamples = false;
+          var buildFlagNoSamples = false;
+
+          $('#select-species')[0].selectize.on("change", function(){
+            if($('#select-species')[0].selectize.getValue().length>0){
+              if($('#select-species')[0].selectize.getValue() === "Not specified"){
+                speciesFlagNoSamples = true;
+                $("#go-button-for-noSamples").prop('disabled', false)
+              }
+              else{
+                speciesFlagNoSamples = true;
+                checkBuildSpeciesNoSampleData(buildFlagNoSamples, speciesFlagNoSamples);
+              }
+            }
+          });
+
+          $('#select-build')[0].selectize.on("change", function(){
+            if($('#select-build')[0].selectize.getValue().length>0){
+              buildFlagNoSamples = true;
+              checkBuildSpeciesNoSampleData(buildFlagNoSamples, speciesFlagNoSamples);
+            }
+          });
+
+          $("#go-button-for-noSamples").removeClass("hide");
           $("#accessing-headers-gif").addClass("hide"); //Hide the loading gif
           $("#select-build-box").removeClass("hide"); //Show the select build box
           $("#go-button-for-load").addClass("hide"); //Hide the sample load button
@@ -1016,10 +1041,12 @@ function _loadVcfFromUrl(url, tbiUrl, sampleNames) {
       $("file-go-button").addClass("hide");
       $("#url-input").val(url);
       $("#tbi-url-input").val(tbiUrl ? tbiUrl : '');
-
     }
     });
+}
 
+function checkBuildSpeciesNoSampleData(buildFlagNoSamples, speciesFlagNoSamples){
+  $("#go-button-for-noSamples").prop('disabled', false);
 }
 
 function enableSampleSelectDropDown(){

--- a/app/app.js
+++ b/app/app.js
@@ -100,7 +100,9 @@ var timings;
 var urlFunctionTime;
 var buildFlag = false; //Sets true when the build is selected in the file upload
 var sampleLoadFlag = false; //Sets true when the samples are selected in the file upload
-
+var demoBuildFlag = false;
+var demoSpeciesFlag = false;
+var demoFlag = true;
 
 /*
 *  Document initialization
@@ -407,12 +409,23 @@ function init() {
         var tbiUrl = decodeUrl(getParameterByName('tbi'));
 
         if (vcfUrl && genomeBuildHelper.getCurrentBuild() && genomeBuildHelper.getCurrentSpecies()) {
+          console.log("hola")
           onRefreshShowAnalysis(vcfUrl, tbiUrl, sampleNamesFromUrl && sampleNamesFromUrl.length >  0 ? sampleNamesFromUrl.split(",") : null);
 
         } else if (vcfUrl) {
-          $('#url-input').val(vcfUrl);
-          if (tbiUrl) {
-            $('#url-tbi-input').val(tbiUrl);
+          console.log(typeof species)
+          if(species === "Not specified" || species === "" || species === "null"){
+            $('#url-input').val("");
+            if (tbiUrl) {
+              $('#url-tbi-input').val("");
+            }
+            displayVcfUrlBox();
+          }
+          else {
+            $('#url-input').val(vcfUrl);
+            if (tbiUrl) {
+              $('#url-tbi-input').val(tbiUrl);
+            }
           }
           displayVcfUrlBox();
         }
@@ -451,7 +464,7 @@ function onRefreshShowAnalysis(vcfUrl, tbiUrl, sampleNamesFromUrl){
         } else {
               $('#samples-filter-header #sample-names').addClass("hide");
         }
-        window.history.pushState({'index.html' : 'bar'},null,"?vcf=" + encodeURIComponent(vcfiobio.getVcfUrl()) + "&tbi=" + encodeURIComponent(vcfiobio.getTbiURL()) + "&samples=" + sampleNamesFromUrl.join(",") + '&build=' + genomeBuildHelper.getCurrentBuildName());
+        window.history.pushState({'index.html' : 'bar'},null,"?vcf=" + encodeURIComponent(vcfiobio.getVcfUrl()) + "&tbi=" + encodeURIComponent(vcfiobio.getTbiURL()) + "&samples=" + sampleNamesFromUrl.join(",") + '&build=' + genomeBuildHelper.getCurrentBuildName() + '&species=' + genomeBuildHelper.getCurrentSpeciesName());
         vcfiobio.setSamples(sampleNamesFromUrl);
 
         vcfiobio.getSampleNames(function(sampleNames){
@@ -493,7 +506,7 @@ function onRefreshShowAnalysis(vcfUrl, tbiUrl, sampleNamesFromUrl){
       } else {
             $('#samples-filter-header #sample-names').addClass("hide");
       }
-      window.history.pushState({'index.html' : 'bar'},null,"?vcf=" + encodeURIComponent(vcfiobio.getVcfUrl()) + "&tbi=" + encodeURIComponent(vcfiobio.getTbiURL()) + "&samples=" + sampleNamesFromUrl.join(",") + '&build=' + genomeBuildHelper.getCurrentBuildName());
+      window.history.pushState({'index.html' : 'bar'},null,"?vcf=" + encodeURIComponent(vcfiobio.getVcfUrl()) + "&tbi=" + encodeURIComponent(vcfiobio.getTbiURL()) + "&samples=" + sampleNamesFromUrl.join(",") + '&build=' + genomeBuildHelper.getCurrentBuildName() + '&species=' + genomeBuildHelper.getCurrentSpeciesName());
       vcfiobio.setSamples(sampleNamesFromUrl);
       loadStats(chromosomeIndex);
     }
@@ -620,6 +633,7 @@ function emailProblem() {
 
 
   function tbiUrlFunction(){
+    demoFlag = false;
     if(document.getElementById("url-input").value.length > 5 && document.getElementById("url-tbi-input").value.length > 5 ){
       var tbiMyTime =  setTimeout(loadFromUrl, 3500);
       $("#sampleDataUrl").addClass("hide");
@@ -630,6 +644,7 @@ function emailProblem() {
 
   function clearUrlFunction(){
     //Clear the samples
+    demoFlag = false;
     var selectTheOptions = $("#vcf-sample-select").selectize();
 		var control = selectTheOptions[0].selectize;
 		control.clearOptions();
@@ -688,14 +703,35 @@ function displayVcfUrlBox() {
     $("#vcf-sample-select-box").addClass("hide");
     $("#all-sample-go-button").addClass("hide");
     $("#sample-go-button").addClass("hide");
-    $("#go-button-for-load").removeClass("hide");
+    // $("#go-button-for-load").removeClass("hide");
 
     vcfiobio.vcfURL = $('#url-input').val();
     vcfiobio.tbiURL = $('#url-tbi-input').val();
     dataSelect.setDefaultBuildFromData(); //builds data for species and genome build
     loadWithSample();
-}
 
+    $('#select-species')[0].selectize.on("change", function(){
+      if($('#select-species')[0].selectize.getValue().length>0){
+        demoSpeciesFlag = true;
+        checkToEnableDemoLoadButton();
+      }
+    })
+
+    $('#select-build')[0].selectize.on("change", function(){
+      if($('#select-build')[0].selectize.getValue().length>0){
+        demoBuildFlag = true;
+        checkToEnableDemoLoadButton();
+      }
+    })
+
+
+}
+function checkToEnableDemoLoadButton(){
+  if(demoBuildFlag && demoSpeciesFlag && demoFlag){
+    $("#go-button-for-load").removeClass("hide");
+    demoFlag = false;
+  }
+}
 function loadWithSample(){
   $("#select-build-box").removeClass("hide");
 }
@@ -880,7 +916,7 @@ function handleSelectedSamplesForFile(){
   } else {
         $('#samples-filter-header #sample-names').addClass("hide");
   }
-  window.history.pushState({'index.html' : 'bar'},null,'?build=' + genomeBuildHelper.getCurrentBuildName());
+  window.history.pushState({'index.html' : 'bar'},null,'?build=' + genomeBuildHelper.getCurrentBuildName() + '&species=' + genomeBuildHelper.getCurrentSpeciesName());
   vcfiobio.setSamples(samples);
 }
 
@@ -1042,7 +1078,7 @@ function handleSelectedSamples(){
         $('#samples-filter-header #sample-names').addClass("hide");
   }
   vcfiobio.setSamples(samples);
-  window.history.pushState({'index.html' : 'bar'},null,"?vcf=" + encodeURIComponent(vcfiobio.getVcfUrl()) + "&tbi=" + encodeURIComponent(vcfiobio.getTbiURL()) + "&samples=" + samples.join(",") + '&build=' + genomeBuildHelper.getCurrentBuildName());
+  window.history.pushState({'index.html' : 'bar'},null,"?vcf=" + encodeURIComponent(vcfiobio.getVcfUrl()) + "&tbi=" + encodeURIComponent(vcfiobio.getTbiURL()) + "&samples=" + samples.join(",") + '&build=' + genomeBuildHelper.getCurrentBuildName() + '&species=' + genomeBuildHelper.getCurrentSpeciesName());
 
 }
 

--- a/app/dataSelect.js
+++ b/app/dataSelect.js
@@ -89,6 +89,7 @@ DataSelect.prototype.disableLoadButton = function() {
 
 DataSelect.prototype.addBuildListener = function() {
 	var me = this;
+	console.log("changing!")
 	if ($('#select-build')[0].selectize) {
 	    $('#select-build')[0].selectize.on('change', function(value) {
 			if (!value.length) {
@@ -97,7 +98,8 @@ DataSelect.prototype.addBuildListener = function() {
 			genomeBuildHelper.setCurrentBuild(value);
 			updateUrl("build", value);
 			buildFlag = true;
-			$('#current-build').text(value);
+			console.log("value", value)
+			// $('#current-build').text(value);
 			me.validateBuildFromData(function(success, message) {
 				if (success) {
 					$('#species-build-warning').addClass("hide");
@@ -126,13 +128,13 @@ DataSelect.prototype.setDefaultBuildFromData = function() {
 
 			} else if (buildsInData.length == 1) {
 				var buildInfo = buildsInData[0];
-
+				console.log("printing from here")
 				me.removeBuildListener();
 				genomeBuildHelper.setCurrentSpecies(buildInfo.species.name);
 				genomeBuildHelper.setCurrentBuild(buildInfo.build.name);
 				$('#select-species')[0].selectize.setValue(buildInfo.species.name);
 				$('#select-build')[0].selectize.setValue(buildInfo.build.name);
-				$('#current-build').text(buildInfo.build.name);
+				// $('#current-build').text(buildInfo.build.name);
 				updateUrl("build", buildInfo.build.name);
 				me.addBuildListener();
 
@@ -151,8 +153,10 @@ DataSelect.prototype.setDefaultBuildFromData = function() {
 }
 
 DataSelect.prototype.validateBuildFromData = function(callback) {
+	console.log("checking and validating")
 	var me = this;
 	me.getBuildsFromData(function(buildsInData) {
+		console.log("buildsInData", buildsInData)
 		if (buildsInData.length == 0) {
 			callback(true);
 
@@ -171,6 +175,7 @@ DataSelect.prototype.validateBuildFromData = function(callback) {
 
 
 DataSelect.prototype.getBuildsFromData = function(callback) {
+	console.log("callback", callback)
 	var me = this;
 
 	me.getHeadersFromVcfs(function(vcfHeaderMap) {

--- a/app/dataSelect.js
+++ b/app/dataSelect.js
@@ -89,16 +89,13 @@ DataSelect.prototype.disableLoadButton = function() {
 
 DataSelect.prototype.addBuildListener = function() {
 	var me = this;
-	console.log("changing!")
 	if ($('#select-build')[0].selectize) {
 	    $('#select-build')[0].selectize.on('change', function(value) {
 			if (!value.length) {
 				return;
 			}
 			genomeBuildHelper.setCurrentBuild(value);
-			updateUrl("build", value);
 			buildFlag = true;
-			console.log("value", value)
 			// $('#current-build').text(value);
 			me.validateBuildFromData(function(success, message) {
 				if (success) {
@@ -128,7 +125,6 @@ DataSelect.prototype.setDefaultBuildFromData = function() {
 
 			} else if (buildsInData.length == 1) {
 				var buildInfo = buildsInData[0];
-				console.log("printing from here")
 				me.removeBuildListener();
 				genomeBuildHelper.setCurrentSpecies(buildInfo.species.name);
 				genomeBuildHelper.setCurrentBuild(buildInfo.build.name);
@@ -153,10 +149,8 @@ DataSelect.prototype.setDefaultBuildFromData = function() {
 }
 
 DataSelect.prototype.validateBuildFromData = function(callback) {
-	console.log("checking and validating")
 	var me = this;
 	me.getBuildsFromData(function(buildsInData) {
-		console.log("buildsInData", buildsInData)
 		if (buildsInData.length == 0) {
 			callback(true);
 
@@ -175,7 +169,6 @@ DataSelect.prototype.validateBuildFromData = function(callback) {
 
 
 DataSelect.prototype.getBuildsFromData = function(callback) {
-	console.log("callback", callback)
 	var me = this;
 
 	me.getHeadersFromVcfs(function(vcfHeaderMap) {

--- a/app/genomeBuildHelper.js
+++ b/app/genomeBuildHelper.js
@@ -6,8 +6,8 @@ function GenomeBuildHelper() {
 	this.speciesToBuilds = {};      // map species to its genome builds
 	this.buildNameToBuild = {};     //
 
-	this.DEFAULT_SPECIES = "";
-	this.DEFAULT_BUILD   = "";
+	this.DEFAULT_SPECIES = "Human";
+	this.DEFAULT_BUILD   = "GRCh37";
 
 	this.ALIAS_UCSC                            = "UCSC";
 	this.ALIAS_REFSEQ_ASSEMBLY_ACCESSION_RANGE = "REFSEQ ASSEMBLY ACCESSION RANGE";
@@ -93,7 +93,9 @@ GenomeBuildHelper.prototype.setCurrentSpecies = function(speciesName) {
 }
 
 GenomeBuildHelper.prototype.setCurrentBuild = function(buildName) {
+	console.log("setCurrentBuild", buildName)
 	this.currentBuild = this.buildNameToBuild[buildName];
+	console.log("this.currentBuild", this.currentBuild)
 }
 
 
@@ -113,6 +115,7 @@ GenomeBuildHelper.prototype.getCurrentBuild = function() {
 	return this.currentBuild ? this.currentBuild : null;
 }
 GenomeBuildHelper.prototype.getCurrentBuildName = function() {
+	console.log("dshgjdhs")
 	return this.currentBuild ? this.currentBuild.name : null;
 }
 

--- a/app/genomeBuildHelper.js
+++ b/app/genomeBuildHelper.js
@@ -93,9 +93,7 @@ GenomeBuildHelper.prototype.setCurrentSpecies = function(speciesName) {
 }
 
 GenomeBuildHelper.prototype.setCurrentBuild = function(buildName) {
-	console.log("setCurrentBuild", buildName)
 	this.currentBuild = this.buildNameToBuild[buildName];
-	console.log("this.currentBuild", this.currentBuild)
 }
 
 
@@ -115,7 +113,6 @@ GenomeBuildHelper.prototype.getCurrentBuild = function() {
 	return this.currentBuild ? this.currentBuild : null;
 }
 GenomeBuildHelper.prototype.getCurrentBuildName = function() {
-	console.log("dshgjdhs")
 	return this.currentBuild ? this.currentBuild.name : null;
 }
 

--- a/app/genomeBuildHelper.js
+++ b/app/genomeBuildHelper.js
@@ -4,10 +4,10 @@ function GenomeBuildHelper() {
 	this.speciesList = [];
 	this.speciesNameToSpecies = {}; // map species name to the species object
 	this.speciesToBuilds = {};      // map species to its genome builds
-	this.buildNameToBuild = {};     // 
+	this.buildNameToBuild = {};     //
 
-	this.DEFAULT_SPECIES = "Human";
-	this.DEFAULT_BUILD   = "GRCh37";
+	this.DEFAULT_SPECIES = "";
+	this.DEFAULT_BUILD   = "";
 
 	this.ALIAS_UCSC                            = "UCSC";
 	this.ALIAS_REFSEQ_ASSEMBLY_ACCESSION_RANGE = "REFSEQ ASSEMBLY ACCESSION RANGE";
@@ -35,14 +35,14 @@ GenomeBuildHelper.prototype.promiseInit = function(options) {
 			type: "GET",
 			dataType: "jsonp",
 	        error: function( xhr, status, errorThrown ) {
-			        
+
 			        console.log( "Error: " + errorThrown );
 			        console.log( "Status: " + status );
 			        console.log( xhr );
 			        reject("An error occurred when loading genomebuild data: " + errorThrown);
 			},
 	        success: function(allSpecies) {
-	        	
+
 	        	me.init(allSpecies);
 
 	        	resolve();
@@ -74,9 +74,10 @@ GenomeBuildHelper.prototype.init = function(allSpecies) {
 				me.speciesToBuilds[species.name] = builds;
 			}
 			builds.push(genomeBuild);
-		
+
 		})
 	});
+	me.speciesList.push({name: "Not specified", value: "Not specified"});
 
 	// Default the species and build
 	if (me.currentSpecies == null) {
@@ -84,7 +85,7 @@ GenomeBuildHelper.prototype.init = function(allSpecies) {
 	}
 	if (me.currentBuild == null) {
 		me.currentBuild = me.buildNameToBuild[me.DEFAULT_BUILD];
-	}	
+	}
 }
 
 GenomeBuildHelper.prototype.setCurrentSpecies = function(speciesName) {
@@ -183,8 +184,8 @@ GenomeBuildHelper.prototype.getBuildResource = function(resourceType) {
 	row will be present in the returned array, representing the build that
 	is specified in all of the files:
 		[{species: the_species_object, build: the_build_object, from: [all bam and vcf files specified as proband,bam]}]
-	In cases where different builds have been specified, more than one row is 
-	returned: 
+	In cases where different builds have been specified, more than one row is
+	returned:
 		[{species: (Human), build: (build GRCh37), from: [{type:vcf, relationship: mother}, {type:bam, relationship: mother}]}]
 		[{species: (Human), build: (build GRCh38), from: [{type:vcf, relationship: proband},{type:bam, relationship: proband}]}]
 */
@@ -196,12 +197,12 @@ GenomeBuildHelper.prototype.getBuildsInHeaders = function(bamHeaderMap, vcfHeade
 		var header = bamHeaderMap[relationship];
 		var buildInfo = me.getBuildFromBamHeader(header);
 		me.parseBuildInfo(buildInfo, relationship, 'bam', theBuilds);
-	}			
+	}
 	for (relationship in vcfHeaderMap) {
 		var header = vcfHeaderMap[relationship];
 		var buildInfo = me.getBuildFromVcfHeader(header);
 		me.parseBuildInfo(buildInfo, relationship, 'vcf', theBuilds);
-	}			
+	}
 
 	return theBuilds;
 }
@@ -235,7 +236,7 @@ GenomeBuildHelper.prototype.getBuildFromBamHeader = function(header) {
 			    	buildInfo.build = assembly;
 			    }
 			 }
-		}	
+		}
 	}
 
 	return buildInfo;
@@ -319,7 +320,7 @@ GenomeBuildHelper.prototype.parseBuildInfo = function(buildInfo, relationship, t
 					theBuilds.push( {species: speciesBuild.species, build: speciesBuild.build, from: [{type: type, relationship: relationship}]});
 				}
 
-			}				
+			}
 		}
 
 	}
@@ -330,7 +331,7 @@ GenomeBuildHelper.prototype.parseBuildInfo = function(buildInfo, relationship, t
 /*
 	Given the species and build names in the file header, try to find the corresponding
 	species and genome build based on matching the header names to the names (name, binomialName, latin_name)
-	of the species and the names (name and aliases) of genome build. 
+	of the species and the names (name and aliases) of genome build.
 */
 GenomeBuildHelper.prototype.getProperSpeciesAndBuild = function(buildInfo) {
 	var me = this;
@@ -346,9 +347,9 @@ GenomeBuildHelper.prototype.getProperSpeciesAndBuild = function(buildInfo) {
 					var species = me.speciesNameToSpecies[speciesName];
 					if (species.name == buildInfo.species || species.binomialName == buildInfo.species || species.latin_name ==  buildInfo.species ) {
 						matchedSpecies = species;
-					} 					
+					}
 				}
-			} 
+			}
 		}
 
 		// For now, just default to Human if species can't be determined from file headers
@@ -390,10 +391,10 @@ GenomeBuildHelper.prototype.getProperSpeciesAndBuild = function(buildInfo) {
 									}
 								}
 							})
-						}																
+						}
 					}
 				})
-							
+
 			} else {
 				// If a build wasn't specified, try to match to a genome build based on reference lengths
 				matchedSpecies.genomeBuilds.forEach(function(build) {
@@ -439,7 +440,7 @@ GenomeBuildHelper.prototype.getProperSpeciesAndBuild = function(buildInfo) {
 }
 
 GenomeBuildHelper.prototype.formatIncompatibleBuildsMessage = function(buildsInData) {
-	var message = null;	
+	var message = null;
 	if (buildsInData && buildsInData.length > 1) {
 		message = "Incompatible builds in files.";
 		buildsInData.forEach(function(buildInfo) {
@@ -456,7 +457,5 @@ GenomeBuildHelper.prototype.formatIncompatibleBuildsMessage = function(buildsInD
 		});
 
 	}
-	return message;	
+	return message;
 }
-
-

--- a/index.html
+++ b/index.html
@@ -162,12 +162,12 @@
               </div>
               <div id="select-build-box" class="hide" style="font-size:18x;width:250px;float:left;margin-left:15px;">
                 <span id="build-label">Genome Build</span>
-                <select required id="select-build" class="selectized" placeholder="select genome build...">
+                <select required id="select-build" class="selectized" placeholder="select/ Enter build">
                 </select>
               </div>
 
-              <button type="button" id="go-button-for-noSamples" style="margin-top:24px; margin-left: -250px;width: 180px;"  class="btn hide" >Load</button>
-              <button type="button" id="go-button-for-load" onclick="demoDataLoad()" style="margin-top:24px; margin-left: -250px;width: 180px;"  class="btn hide">Load</button>
+              <button disabled type="button" id="go-button-for-noSamples" style="margin-top:24px; margin-left: -250px;width: 180px;"  class="btn hide" >Load</button>
+              <button disabled type="button" id="go-button-for-load" onclick="demoDataLoad()" style="margin-top:24px; margin-left: -250px;width: 180px;"  class="btn hide">Load</button>
 
               <div id="vcf-sample-box" class="hide" style="font-size:18x;width:240px;float:left;margin-left:15px; margin-right:10px; margin-top:0px;" style="text-align:center">
                 <div id="vcf-sample-select-box" >

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
               </div>
 
               <button disabled type="button" id="go-button-for-noSamples" style="margin-top:24px; margin-left: -250px;width: 180px;"  class="btn hide" >Load</button>
-              <button disabled type="button" id="go-button-for-load" onclick="demoDataLoad()" style="margin-top:24px; margin-left: -250px;width: 180px;"  class="btn hide">Load</button>
+              <button type="button" id="go-button-for-load" onclick="demoDataLoad()" style="margin-top:24px; margin-left: -250px;width: 180px;"  class="btn hide">Load</button>
 
               <div id="vcf-sample-box" class="hide" style="font-size:18x;width:240px;float:left;margin-left:15px; margin-right:10px; margin-top:0px;" style="text-align:center">
                 <div id="vcf-sample-select-box" >


### PR DESCRIPTION
This PR has two updates: 
1. Entering build for non-human VCF file is now optional. 
When the user enters a non-human VCF URL or uploads file, the load button is now disabled. The user can now select  "Not specified" from the Species dropdown. Once "Not specified" is selected the load button is enabled.   
![Screen Shot 2019-05-16 at 3 54 56 PM](https://user-images.githubusercontent.com/16284713/57889819-05d34180-77f3-11e9-88fe-5868ca79baec.png)
I test with these files: 
https://s3.amazonaws.com/iobio/app_testing/vcf_files/delete_me/cannibus/SRR8346822_to_Harvard_Assembly.vcf.gz
https://s3.amazonaws.com/iobio/app_testing/vcf_files/delete_me/cannibus/SRR8346822_to_Harvard_Assembly.vcf.gz.tbi
For Humans and Mouse VCF files, the behavior is the same as before. 

2. The species dropdown is now visible for file upload. 
